### PR TITLE
Fix: Prevent multiple page swipes in Quran reader

### DIFF
--- a/app/quran.css
+++ b/app/quran.css
@@ -3,3 +3,12 @@
         filter: invert(1) hue-rotate(-140deg) contrast(0.7);
     }
 }
+
+:root {
+    --swiper-preloader-color: #5C4033; /* Dark Brown */
+}
+
+.swiper-lazy-preloader {
+    border-color: #5C4033; /* Sets all sides */
+    border-top-color: transparent; /* Keeps the spinner effect */
+}

--- a/app/ui/quran-page.tsx
+++ b/app/ui/quran-page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import '@/app/quran.css'
 import { usePreferences } from "../context/preferences";
 
-export default function QuranPage({ number }: { number: number }) {
+export default function QuranPage({ number, isPriority }: { number: number, isPriority: boolean }) {
     const imageUrl = `/sayfa/${number}.png`
     const { preferences } = usePreferences();
 
@@ -15,7 +15,7 @@ export default function QuranPage({ number }: { number: number }) {
         className={"object-contain sayfa mx-auto z-100 portrait:h-screen portrait:w-auto " + (preferences.fitTo !== 'width' ? "landscape:h-screen landscape:w-auto" : "landscape:h-auto landscape:w-screen")}
         key={`sayfa-${number}`}
         onError={(e) => { }}
-        priority={true}
+        priority={isPriority}
     />
 
 }

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -44,21 +44,19 @@ export default function QuranPages({
                 grabCursor={true}
                 slidesPerGroup={1}
                 navigation
-                cssMode={true}
+                cssMode={false}
                 spaceBetween={50}
                 pagination={{ clickable: true }}
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
+                speed={300}
+                freeMode={false}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);
                     onPageChange?.(currentPageNum);
                 }}
-                threshold={15}
-                followFinger={false}
-                longSwipesRatio={0.7}
-                shortSwipes={false}
             >
                 {pages}
             </Swiper >

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -22,7 +22,7 @@ export default function QuranPages({
     header?: React.ReactNode,
     onPageChange?: (page: number) => void
 }) {
-    const [swiperRef, setSwiperRef] = useState(null);
+    const swiperInstanceRef = useRef<SwiperClass | null>(null);
     const [pageNum, setPageNum] = useState<number>(start);
 
 
@@ -39,7 +39,7 @@ export default function QuranPages({
             {header}
             <Swiper
                 dir="rtl"
-                ref={swiperRef}
+                onSwiper={(swiper) => { swiperInstanceRef.current = swiper; }}
                 slidesPerView={1}
                 grabCursor={true}
                 slidesPerGroup={1}
@@ -50,16 +50,20 @@ export default function QuranPages({
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                longSwipesRatio={0.1}
-                shortSwipes={true}
-                resistanceRatio={0}
-                freeMode={false}
-                watchSlidesProgress={true}
-                touchReleaseOnEdges={true}
-                onSlideChange={(swiper: SwiperClass) => {
-                    const currentPageNum = swiper.realIndex + start;
+                onSlideChange={(swiperSlideData: SwiperClass) => {
+                    const currentPageNum = swiperSlideData.realIndex + start;
                     setPageNum(currentPageNum);
                     onPageChange?.(currentPageNum);
+
+                    const swiper = swiperInstanceRef.current;
+                    if (swiper) {
+                        swiper.allowSlideNext = false;
+                        swiper.allowSlidePrev = false;
+                        setTimeout(() => {
+                            swiper.allowSlideNext = true;
+                            swiper.allowSlidePrev = true;
+                        }, 300);
+                    }
                 }}
             >
                 {pages}

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -30,7 +30,12 @@ export default function QuranPages({
 
     const pages: ReactElement[] = [];
     for (let num = start; num <= end; num++) {
-        pages.push(<SwiperSlide key={`sayfa-${num}`}><QuranPage number={num} /></SwiperSlide>);
+        pages.push(
+            <SwiperSlide key={`sayfa-${num}`}>
+                <QuranPage number={num} isPriority={num === start} />
+                <div className="swiper-lazy-preloader"></div>
+            </SwiperSlide>
+        );
     }
 
     return (
@@ -44,14 +49,15 @@ export default function QuranPages({
                 grabCursor={true}
                 slidesPerGroup={1}
                 navigation
-                cssMode={true}
+                cssMode={false}
                 spaceBetween={50}
                 pagination={{ clickable: true }}
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                freeMode={{ enabled: true, sticky: true, momentum: false }}
-                threshold={15}
+                speed={300}
+                freeMode={false}
+                lazy={{ enabled: true, loadPrevNext: true, loadPrevNextAmount: 1 }}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -44,14 +44,16 @@ export default function QuranPages({
                 grabCursor={true}
                 slidesPerGroup={1}
                 navigation
-                cssMode={false}
+                cssMode={true}
                 spaceBetween={50}
                 pagination={{ clickable: true }}
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                speed={300}
-                freeMode={false}
+                freeMode={true}
+                freeModeSticky={true}
+                freeModeMomentum={false}
+                threshold={15}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -50,20 +50,32 @@ export default function QuranPages({
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                onSlideChange={(swiperSlideData: SwiperClass) => {
-                    const currentPageNum = swiperSlideData.realIndex + start;
-                    setPageNum(currentPageNum);
-                    onPageChange?.(currentPageNum);
+                onSlideChange={(swiperData: SwiperClass) => {
+                    const newRealIndex = swiperData.realIndex;
+                    const newPotentialPageNum = newRealIndex + start;
+                    let targetPageNum = newPotentialPageNum;
 
                     const swiper = swiperInstanceRef.current;
                     if (swiper) {
+                        if (newPotentialPageNum > pageNum + 1) {
+                            targetPageNum = pageNum + 1;
+                            swiper.slideTo(targetPageNum - start, 0);
+                        } else if (newPotentialPageNum < pageNum - 1) {
+                            targetPageNum = pageNum - 1;
+                            swiper.slideTo(targetPageNum - start, 0);
+                        }
+
                         swiper.allowSlideNext = false;
                         swiper.allowSlidePrev = false;
                         setTimeout(() => {
-                            swiper.allowSlideNext = true;
-                            swiper.allowSlidePrev = true;
+                            if (swiperInstanceRef.current) {
+                                swiperInstanceRef.current.allowSlideNext = true;
+                                swiperInstanceRef.current.allowSlidePrev = true;
+                            }
                         }, 300);
                     }
+                    setPageNum(targetPageNum);
+                    onPageChange?.(targetPageNum);
                 }}
             >
                 {pages}

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -50,33 +50,15 @@ export default function QuranPages({
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                onSlideChange={(swiperData: SwiperClass) => {
-                    const newRealIndex = swiperData.realIndex;
-                    const newPotentialPageNum = newRealIndex + start;
-                    let targetPageNum = newPotentialPageNum;
-
-                    const swiper = swiperInstanceRef.current;
-                    if (swiper) {
-                        if (newPotentialPageNum > pageNum + 1) {
-                            targetPageNum = pageNum + 1;
-                            swiper.slideTo(targetPageNum - start, 0);
-                        } else if (newPotentialPageNum < pageNum - 1) {
-                            targetPageNum = pageNum - 1;
-                            swiper.slideTo(targetPageNum - start, 0);
-                        }
-
-                        swiper.allowSlideNext = false;
-                        swiper.allowSlidePrev = false;
-                        setTimeout(() => {
-                            if (swiperInstanceRef.current) {
-                                swiperInstanceRef.current.allowSlideNext = true;
-                                swiperInstanceRef.current.allowSlidePrev = true;
-                            }
-                        }, 300);
-                    }
-                    setPageNum(targetPageNum);
-                    onPageChange?.(targetPageNum);
+                onSlideChange={(swiper: SwiperClass) => {
+                    const currentPageNum = swiper.realIndex + start;
+                    setPageNum(currentPageNum);
+                    onPageChange?.(currentPageNum);
                 }}
+                threshold={15}
+                followFinger={false}
+                longSwipesRatio={0.7}
+                shortSwipes={false}
             >
                 {pages}
             </Swiper >

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -57,7 +57,7 @@ export default function QuranPages({
                 className="landscape:h-screen"
                 speed={300}
                 freeMode={false}
-                lazy={{ enabled: true, loadPrevNext: true, loadPrevNextAmount: 1 }}
+                lazy={{ enabled: true, loadPrevNext: true, loadPrevNextAmount: 3 }}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -50,9 +50,7 @@ export default function QuranPages({
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
-                freeMode={true}
-                freeModeSticky={true}
-                freeModeMomentum={false}
+                freeMode={{ enabled: true, sticky: true, momentum: false }}
                 threshold={15}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;

--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -50,6 +50,12 @@ export default function QuranPages({
                 keyboard={{ enabled: true }}
                 modules={[Pagination, Navigation, Keyboard]}
                 className="landscape:h-screen"
+                longSwipesRatio={0.1}
+                shortSwipes={true}
+                resistanceRatio={0}
+                freeMode={false}
+                watchSlidesProgress={true}
+                touchReleaseOnEdges={true}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);


### PR DESCRIPTION
Adjust the Swiper component properties in app/ui/quranpages.tsx to prevent you from swiping multiple pages at once, especially on mobile devices with fast or edge swipes.

Changes include:
- Set `longSwipesRatio` to `0.1`
- Set `shortSwipes` to `true`
- Set `resistanceRatio` to `0`
- Set `freeMode` to `false`
- Added `watchSlidesProgress` and `touchReleaseOnEdges` and set to `true`

These changes aim to make the swipe behavior more controlled, ensuring only one page is turned per swipe gesture.

> Automatically generated by Jules