### PR TITLE
Fix: Remove Swiper 'lazy' prop to resolve TypeScript build error

### DIFF
--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -57,7 +57,6 @@ export default function QuranPages({
                 className="landscape:h-screen"
                 speed={300}
                 freeMode={false}
-                lazy={{ enabled: true, loadPrevNext: true, loadPrevNextAmount: 3 }}
                 onSlideChange={(swiper: SwiperClass) => {
                     const currentPageNum = swiper.realIndex + start;
                     setPageNum(currentPageNum);


### PR DESCRIPTION
Removed the `lazy` prop from the `<Swiper>` component in `app/ui/quranpages.tsx`. 

> Built by jules