### PR TITLE
feat: Implement eager loading for Quran pages

### DIFF
--- a/app/ui/quranpages.tsx
+++ b/app/ui/quranpages.tsx
@@ -30,9 +30,12 @@ export default function QuranPages({
 
     const pages: ReactElement[] = [];
     for (let num = start; num <= end; num++) {
+        // Determine if the page should be loaded with priority
+        // Preload current, one previous, and two next pages
+        const shouldBePriority = num >= pageNum - 1 && num <= pageNum + 2;
         pages.push(
             <SwiperSlide key={`sayfa-${num}`}>
-                <QuranPage number={num} isPriority={num === start} />
+                <QuranPage number={num} isPriority={shouldBePriority} />
                 <div className="swiper-lazy-preloader"></div>
             </SwiperSlide>
         );


### PR DESCRIPTION
> via [jules](https://jules.google.com)

To address slow page swiping, this change dynamically sets the `priority` attribute on `next/image` components used for displaying Quran pages.

The `QuranPages` component now prioritizes loading for:
- The currently visible page
- The page immediately preceding the current page
- Two pages immediately following the current page

This instructs `next/image` to preload these pages, aiming for a smoother user experience when swiping between pages. The previous behavior of only prioritizing the very first page in a set has been updated to this dynamic window around the active page.